### PR TITLE
Feature/ci313 phpunit adaptation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-<p align="center">
+<div align="center">
     <a href="https://codeigniter.com/" target="_blank">
-        <img src="https://codeigniter.com/assets/images/ci-logo-big.png" height="100px">
+        <img src="https://codeigniter.com/assets/icons/ci-logo.png" height="100px">
     </a>
     <h1 align="center">CodeIgniter PHPUnit Test</h1>
     <br>
-</p>
+</div>
 
 CodeIgniter 3 PHPUnit Test extension library
 
 [![Latest Stable Version](https://poser.pugx.org/yidas/codeigniter-phpunit/v/stable?format=flat-square)](https://packagist.org/packages/yidas/codeigniter-phpunit)
 [![License](https://poser.pugx.org/yidas/codeigniter-phpunit/license?format=flat-square)](https://packagist.org/packages/yidas/codeigniter-phpunit)
 
-This RESTful API extension is collected into [yidas/codeigniter-pack](https://github.com/yidas/codeigniter-pack) which is a complete solution for Codeigniter framework.
+Official adaptation of the [yidas/codeigniter-phpunit](https://github.com/yidas/codeigniter-phpunit) repository for compatibility with **CodeIgniter 3.1.13** and **PHP 7.1+**.
 
 FEATURES
 --------
@@ -38,8 +38,8 @@ REQUIREMENTS
 
 This library requires the following:
 
-- PHP 5.3.0+
-- CodeIgniter 3.0.0+
+- PHP 7.1.0+
+- CodeIgniter 3.1.13+
 
 ---
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -66,11 +66,12 @@
 switch (ENVIRONMENT)
 {
 	case 'development':
+	case 'dnamic':
 		error_reporting(-1);
 		ini_set('display_errors', 1);
 	break;
 
-	case 'testing':
+	case 'staging':
 	case 'production':
 		ini_set('display_errors', 0);
 		if (version_compare(PHP_VERSION, '5.3', '>='))

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,17 @@
 {
-    "name": "yidas/codeigniter-phpunit",
-    "description": "CodeIgniter 3 PHPUnit Test extension library",
+    "name": "edgcarmu/codeigniter-phpunit",
+    "description": "Official adaptation of yidas/codeigniter-phpunit for CodeIgniter 3.1.11 and PHP 7.1+",
     "keywords": ["codeIgniter", "phpunit", "unit-test", "test-driven-development"],
-    "homepage": "https://github.com/yidas/codeigniter-phpunit",
+    "homepage": "https://github.com/edgcarmu/codeigniter-phpunit",
     "type": "library",
     "license": "MIT",
     "support": {
-        "issues": "https://github.com/yidas/codeigniter-phpunit/issues",
-        "source": "https://github.com/yidas/codeigniter-phpunit"
+        "issues": "https://github.com/edgcarmu/codeigniter-phpunit/issues",
+        "source": "https://github.com/edgcarmu/codeigniter-phpunit"
     },
     "minimum-stability": "stable",
     "require": {
-        "phpunit/phpunit": ">=5.5.0"
+        "php": ">=7.1",
+        "phpunit/phpunit": "^7.5"
     }
 }

--- a/core/CodeIgniter.php
+++ b/core/CodeIgniter.php
@@ -1,13 +1,20 @@
 <?php
 /**
- * yidas/codeigniter-phpunit
- * 
- * @see https://github.com/yidas/codeigniter-phpunit
- * 
+ * edgcarmu/codeigniter-phpunit
+ *
+ * Official adaptation of yidas/codeigniter-phpunit
+ * for CodeIgniter 3.1.11 and PHP 7.1+
+ *
+ * @see https://github.com/edgcarmu/codeigniter-phpunit
+ * @original https://github.com/yidas/codeigniter-phpunit by Nick Tsai
+ *
  * Modifications:
- * Line 447: Force cancel 404 check
- * Line 518: Force giving CI with CI_Controller
- * Line 532: Comment out Controller call
+ * - Based on yidas/codeigniter-phpunit v1.1.0
+ * - Line 460: Force cancel 404 check
+ * - Line 536: Force giving CI with CI_Controller
+ * - Line 550: Commented out Controller call
+ *
+ * Maintained by @edgcarmu
  */
 
 /**
@@ -66,29 +73,29 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @var	string
  *
  */
-	const CI_VERSION = '3.1.10';
+const CI_VERSION = '3.1.11';
 
 /*
  * ------------------------------------------------------
  *  Load the framework constants
  * ------------------------------------------------------
  */
-	if (file_exists(APPPATH.'config/'.ENVIRONMENT.'/constants.php'))
-	{
-		require_once(APPPATH.'config/'.ENVIRONMENT.'/constants.php');
-	}
+if (file_exists(APPPATH.'config/'.ENVIRONMENT.'/constants.php'))
+{
+  require_once(APPPATH.'config/'.ENVIRONMENT.'/constants.php');
+}
 
-	if (file_exists(APPPATH.'config/constants.php'))
-	{
-		require_once(APPPATH.'config/constants.php');
-	}
+if (file_exists(APPPATH.'config/constants.php'))
+{
+  require_once(APPPATH.'config/constants.php');
+}
 
 /*
  * ------------------------------------------------------
  *  Load the global functions
  * ------------------------------------------------------
  */
-	require_once(BASEPATH.'core/Common.php');
+require_once(BASEPATH.'core/Common.php');
 
 
 /*
@@ -99,45 +106,45 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 if ( ! is_php('5.4'))
 {
-	ini_set('magic_quotes_runtime', 0);
+  ini_set('magic_quotes_runtime', 0);
 
-	if ((bool) ini_get('register_globals'))
-	{
-		$_protected = array(
-			'_SERVER',
-			'_GET',
-			'_POST',
-			'_FILES',
-			'_REQUEST',
-			'_SESSION',
-			'_ENV',
-			'_COOKIE',
-			'GLOBALS',
-			'HTTP_RAW_POST_DATA',
-			'system_path',
-			'application_folder',
-			'view_folder',
-			'_protected',
-			'_registered'
-		);
+  if ((bool) ini_get('register_globals'))
+  {
+    $_protected = array(
+      '_SERVER',
+      '_GET',
+      '_POST',
+      '_FILES',
+      '_REQUEST',
+      '_SESSION',
+      '_ENV',
+      '_COOKIE',
+      'GLOBALS',
+      'HTTP_RAW_POST_DATA',
+      'system_path',
+      'application_folder',
+      'view_folder',
+      '_protected',
+      '_registered'
+    );
 
-		$_registered = ini_get('variables_order');
-		foreach (array('E' => '_ENV', 'G' => '_GET', 'P' => '_POST', 'C' => '_COOKIE', 'S' => '_SERVER') as $key => $superglobal)
-		{
-			if (strpos($_registered, $key) === FALSE)
-			{
-				continue;
-			}
+    $_registered = ini_get('variables_order');
+    foreach (array('E' => '_ENV', 'G' => '_GET', 'P' => '_POST', 'C' => '_COOKIE', 'S' => '_SERVER') as $key => $superglobal)
+    {
+      if (strpos($_registered, $key) === FALSE)
+      {
+        continue;
+      }
 
-			foreach (array_keys($$superglobal) as $var)
-			{
-				if (isset($GLOBALS[$var]) && ! in_array($var, $_protected, TRUE))
-				{
-					$GLOBALS[$var] = NULL;
-				}
-			}
-		}
-	}
+      foreach (array_keys($$superglobal) as $var)
+      {
+        if (isset($GLOBALS[$var]) && ! in_array($var, $_protected, TRUE))
+        {
+          $GLOBALS[$var] = NULL;
+        }
+      }
+    }
+  }
 }
 
 
@@ -146,9 +153,9 @@ if ( ! is_php('5.4'))
  *  Define a custom error handler so we can log PHP errors
  * ------------------------------------------------------
  */
-	set_error_handler('_error_handler');
-	set_exception_handler('_exception_handler');
-	register_shutdown_function('_shutdown_handler');
+set_error_handler('_error_handler');
+set_exception_handler('_exception_handler');
+register_shutdown_function('_shutdown_handler');
 
 /*
  * ------------------------------------------------------
@@ -166,56 +173,56 @@ if ( ! is_php('5.4'))
  * Note: Since the config file data is cached it doesn't
  * hurt to load it here.
  */
-	if ( ! empty($assign_to_config['subclass_prefix']))
-	{
-		get_config(array('subclass_prefix' => $assign_to_config['subclass_prefix']));
-	}
+if ( ! empty($assign_to_config['subclass_prefix']))
+{
+  get_config(array('subclass_prefix' => $assign_to_config['subclass_prefix']));
+}
 
 /*
  * ------------------------------------------------------
  *  Should we use a Composer autoloader?
  * ------------------------------------------------------
  */
-	if ($composer_autoload = config_item('composer_autoload'))
-	{
-		if ($composer_autoload === TRUE)
-		{
-			file_exists(APPPATH.'vendor/autoload.php')
-				? require_once(APPPATH.'vendor/autoload.php')
-				: log_message('error', '$config[\'composer_autoload\'] is set to TRUE but '.APPPATH.'vendor/autoload.php was not found.');
-		}
-		elseif (file_exists($composer_autoload))
-		{
-			require_once($composer_autoload);
-		}
-		else
-		{
-			log_message('error', 'Could not find the specified $config[\'composer_autoload\'] path: '.$composer_autoload);
-		}
-	}
+if ($composer_autoload = config_item('composer_autoload'))
+{
+  if ($composer_autoload === TRUE)
+  {
+    file_exists(APPPATH.'vendor/autoload.php')
+      ? require_once(APPPATH.'vendor/autoload.php')
+      : log_message('error', '$config[\'composer_autoload\'] is set to TRUE but '.APPPATH.'vendor/autoload.php was not found.');
+  }
+  elseif (file_exists($composer_autoload))
+  {
+    require_once($composer_autoload);
+  }
+  else
+  {
+    log_message('error', 'Could not find the specified $config[\'composer_autoload\'] path: '.$composer_autoload);
+  }
+}
 
 /*
  * ------------------------------------------------------
  *  Start the timer... tick tock tick tock...
  * ------------------------------------------------------
  */
-	$BM =& load_class('Benchmark', 'core');
-	$BM->mark('total_execution_time_start');
-	$BM->mark('loading_time:_base_classes_start');
+$BM =& load_class('Benchmark', 'core');
+$BM->mark('total_execution_time_start');
+$BM->mark('loading_time:_base_classes_start');
 
 /*
  * ------------------------------------------------------
  *  Instantiate the hooks class
  * ------------------------------------------------------
  */
-	$EXT =& load_class('Hooks', 'core');
+$EXT =& load_class('Hooks', 'core');
 
 /*
  * ------------------------------------------------------
  *  Is there a "pre_system" hook?
  * ------------------------------------------------------
  */
-	$EXT->call_hook('pre_system');
+$EXT->call_hook('pre_system');
 
 /*
  * ------------------------------------------------------
@@ -227,16 +234,16 @@ if ( ! is_php('5.4'))
  * depending on another class that uses it.
  *
  */
-	$CFG =& load_class('Config', 'core');
+$CFG =& load_class('Config', 'core');
 
-	// Do we have any manually set config items in the index.php file?
-	if (isset($assign_to_config) && is_array($assign_to_config))
-	{
-		foreach ($assign_to_config as $key => $value)
-		{
-			$CFG->set_item($key, $value);
-		}
-	}
+// Do we have any manually set config items in the index.php file?
+if (isset($assign_to_config) && is_array($assign_to_config))
+{
+  foreach ($assign_to_config as $key => $value)
+  {
+    $CFG->set_item($key, $value);
+  }
+}
 
 /*
  * ------------------------------------------------------
@@ -252,42 +259,42 @@ if ( ! is_php('5.4'))
  * in it's constructor, but it's _not_ class-specific.
  *
  */
-	$charset = strtoupper(config_item('charset'));
-	ini_set('default_charset', $charset);
+$charset = strtoupper(config_item('charset'));
+ini_set('default_charset', $charset);
 
-	if (extension_loaded('mbstring'))
-	{
-		define('MB_ENABLED', TRUE);
-		// mbstring.internal_encoding is deprecated starting with PHP 5.6
-		// and it's usage triggers E_DEPRECATED messages.
-		@ini_set('mbstring.internal_encoding', $charset);
-		// This is required for mb_convert_encoding() to strip invalid characters.
-		// That's utilized by CI_Utf8, but it's also done for consistency with iconv.
-		mb_substitute_character('none');
-	}
-	else
-	{
-		define('MB_ENABLED', FALSE);
-	}
+if (extension_loaded('mbstring'))
+{
+  define('MB_ENABLED', TRUE);
+  // mbstring.internal_encoding is deprecated starting with PHP 5.6
+  // and it's usage triggers E_DEPRECATED messages.
+  @ini_set('mbstring.internal_encoding', $charset);
+  // This is required for mb_convert_encoding() to strip invalid characters.
+  // That's utilized by CI_Utf8, but it's also done for consistency with iconv.
+  mb_substitute_character('none');
+}
+else
+{
+  define('MB_ENABLED', FALSE);
+}
 
-	// There's an ICONV_IMPL constant, but the PHP manual says that using
-	// iconv's predefined constants is "strongly discouraged".
-	if (extension_loaded('iconv'))
-	{
-		define('ICONV_ENABLED', TRUE);
-		// iconv.internal_encoding is deprecated starting with PHP 5.6
-		// and it's usage triggers E_DEPRECATED messages.
-		@ini_set('iconv.internal_encoding', $charset);
-	}
-	else
-	{
-		define('ICONV_ENABLED', FALSE);
-	}
+// There's an ICONV_IMPL constant, but the PHP manual says that using
+// iconv's predefined constants is "strongly discouraged".
+if (extension_loaded('iconv'))
+{
+  define('ICONV_ENABLED', TRUE);
+  // iconv.internal_encoding is deprecated starting with PHP 5.6
+  // and it's usage triggers E_DEPRECATED messages.
+  @ini_set('iconv.internal_encoding', $charset);
+}
+else
+{
+  define('ICONV_ENABLED', FALSE);
+}
 
-	if (is_php('5.6'))
-	{
-		ini_set('php.internal_encoding', $charset);
-	}
+if (is_php('5.6'))
+{
+  ini_set('php.internal_encoding', $charset);
+}
 
 /*
  * ------------------------------------------------------
@@ -295,69 +302,69 @@ if ( ! is_php('5.4'))
  * ------------------------------------------------------
  */
 
-	require_once(BASEPATH.'core/compat/mbstring.php');
-	require_once(BASEPATH.'core/compat/hash.php');
-	require_once(BASEPATH.'core/compat/password.php');
-	require_once(BASEPATH.'core/compat/standard.php');
+require_once(BASEPATH.'core/compat/mbstring.php');
+require_once(BASEPATH.'core/compat/hash.php');
+require_once(BASEPATH.'core/compat/password.php');
+require_once(BASEPATH.'core/compat/standard.php');
 
 /*
  * ------------------------------------------------------
  *  Instantiate the UTF-8 class
  * ------------------------------------------------------
  */
-	$UNI =& load_class('Utf8', 'core');
+$UNI =& load_class('Utf8', 'core');
 
 /*
  * ------------------------------------------------------
  *  Instantiate the URI class
  * ------------------------------------------------------
  */
-	$URI =& load_class('URI', 'core');
+$URI =& load_class('URI', 'core');
 
 /*
  * ------------------------------------------------------
  *  Instantiate the routing class and set the routing
  * ------------------------------------------------------
  */
-	$RTR =& load_class('Router', 'core', isset($routing) ? $routing : NULL);
+$RTR =& load_class('Router', 'core', isset($routing) ? $routing : NULL);
 
 /*
  * ------------------------------------------------------
  *  Instantiate the output class
  * ------------------------------------------------------
  */
-	$OUT =& load_class('Output', 'core');
+$OUT =& load_class('Output', 'core');
 
 /*
  * ------------------------------------------------------
  *	Is there a valid cache file? If so, we're done...
  * ------------------------------------------------------
  */
-	if ($EXT->call_hook('cache_override') === FALSE && $OUT->_display_cache($CFG, $URI) === TRUE)
-	{
-		exit;
-	}
+if ($EXT->call_hook('cache_override') === FALSE && $OUT->_display_cache($CFG, $URI) === TRUE)
+{
+  exit;
+}
 
 /*
  * -----------------------------------------------------
  * Load the security class for xss and csrf support
  * -----------------------------------------------------
  */
-	$SEC =& load_class('Security', 'core');
+$SEC =& load_class('Security', 'core');
 
 /*
  * ------------------------------------------------------
  *  Load the Input class and sanitize globals
  * ------------------------------------------------------
  */
-	$IN	=& load_class('Input', 'core');
+$IN	=& load_class('Input', 'core');
 
 /*
  * ------------------------------------------------------
  *  Load the Language class
  * ------------------------------------------------------
  */
-	$LANG =& load_class('Lang', 'core');
+$LANG =& load_class('Lang', 'core');
 
 /*
  * ------------------------------------------------------
@@ -365,28 +372,28 @@ if ( ! is_php('5.4'))
  * ------------------------------------------------------
  *
  */
-	// Load the base controller class
-	require_once BASEPATH.'core/Controller.php';
+// Load the base controller class
+require_once BASEPATH.'core/Controller.php';
 
-	/**
-	 * Reference to the CI_Controller method.
-	 *
-	 * Returns current CI instance object
-	 *
-	 * @return CI_Controller
-	 */
-	function &get_instance()
-	{
-		return CI_Controller::get_instance();
-	}
+/**
+ * Reference to the CI_Controller method.
+ *
+ * Returns current CI instance object
+ *
+ * @return CI_Controller
+ */
+function &get_instance()
+{
+  return CI_Controller::get_instance();
+}
 
-	if (file_exists(APPPATH.'core/'.$CFG->config['subclass_prefix'].'Controller.php'))
-	{
-		require_once APPPATH.'core/'.$CFG->config['subclass_prefix'].'Controller.php';
-	}
+if (file_exists(APPPATH.'core/'.$CFG->config['subclass_prefix'].'Controller.php'))
+{
+  require_once APPPATH.'core/'.$CFG->config['subclass_prefix'].'Controller.php';
+}
 
-	// Set a mark point for benchmarking
-	$BM->mark('loading_time:_base_classes_end');
+// Set a mark point for benchmarking
+$BM->mark('loading_time:_base_classes_end');
 
 /*
  * ------------------------------------------------------
@@ -409,163 +416,162 @@ if ( ! is_php('5.4'))
  *  controller methods that begin with an underscore.
  */
 
-	$e404 = FALSE;
-	$class = ucfirst($RTR->class);
-	$method = $RTR->method;
+$e404 = FALSE;
+$class = ucfirst($RTR->class);
+$method = $RTR->method;
 
-	if (empty($class) OR ! file_exists(APPPATH.'controllers/'.$RTR->directory.$class.'.php'))
-	{
-		$e404 = TRUE;
-	}
-	else
-	{
-		require_once(APPPATH.'controllers/'.$RTR->directory.$class.'.php');
+if (empty($class) OR ! file_exists(APPPATH.'controllers/'.$RTR->directory.$class.'.php'))
+{
+  $e404 = TRUE;
+}
+else
+{
+  require_once(APPPATH.'controllers/'.$RTR->directory.$class.'.php');
 
-		if ( ! class_exists($class, FALSE) OR $method[0] === '_' OR method_exists('CI_Controller', $method))
-		{
-			$e404 = TRUE;
-		}
-		elseif (method_exists($class, '_remap'))
-		{
-			$params = array($method, array_slice($URI->rsegments, 2));
-			$method = '_remap';
-		}
-		elseif ( ! method_exists($class, $method))
-		{
-			$e404 = TRUE;
-		}
-		/**
-		 * DO NOT CHANGE THIS, NOTHING ELSE WORKS!
-		 *
-		 * - method_exists() returns true for non-public methods, which passes the previous elseif
-		 * - is_callable() returns false for PHP 4-style constructors, even if there's a __construct()
-		 * - method_exists($class, '__construct') won't work because CI_Controller::__construct() is inherited
-		 * - People will only complain if this doesn't work, even though it is documented that it shouldn't.
-		 *
-		 * ReflectionMethod::isConstructor() is the ONLY reliable check,
-		 * knowing which method will be executed as a constructor.
-		 */
-		elseif ( ! is_callable(array($class, $method)))
-		{
-			$reflection = new ReflectionMethod($class, $method);
-			if ( ! $reflection->isPublic() OR $reflection->isConstructor())
-			{
-				$e404 = TRUE;
-			}
-		}
-	}
+  if ( ! class_exists($class, FALSE) OR $method[0] === '_' OR method_exists('CI_Controller', $method))
+  {
+    $e404 = TRUE;
+  }
+  elseif (method_exists($class, '_remap'))
+  {
+    $params = array($method, array_slice($URI->rsegments, 2));
+    $method = '_remap';
+  }
+  elseif ( ! method_exists($class, $method))
+  {
+    $e404 = TRUE;
+  }
+  /**
+   * DO NOT CHANGE THIS, NOTHING ELSE WORKS!
+   *
+   * - method_exists() returns true for non-public methods, which passes the previous elseif
+   * - is_callable() returns false for PHP 4-style constructors, even if there's a __construct()
+   * - method_exists($class, '__construct') won't work because CI_Controller::__construct() is inherited
+   * - People will only complain if this doesn't work, even though it is documented that it shouldn't.
+   *
+   * ReflectionMethod::isConstructor() is the ONLY reliable check,
+   * knowing which method will be executed as a constructor.
+   */
+  elseif ( ! is_callable(array($class, $method)))
+  {
+    $reflection = new ReflectionMethod($class, $method);
+    if ( ! $reflection->isPublic() OR $reflection->isConstructor())
+    {
+      $e404 = false;
+    }
+  }
+}
 
-	$e404 = false;
-	if ($e404)
-	{
-		if ( ! empty($RTR->routes['404_override']))
-		{
-			if (sscanf($RTR->routes['404_override'], '%[^/]/%s', $error_class, $error_method) !== 2)
-			{
-				$error_method = 'index';
-			}
+if ($e404)
+{
+  if ( ! empty($RTR->routes['404_override']))
+  {
+    if (sscanf($RTR->routes['404_override'], '%[^/]/%s', $error_class, $error_method) !== 2)
+    {
+      $error_method = 'index';
+    }
 
-			$error_class = ucfirst($error_class);
+    $error_class = ucfirst($error_class);
 
-			if ( ! class_exists($error_class, FALSE))
-			{
-				if (file_exists(APPPATH.'controllers/'.$RTR->directory.$error_class.'.php'))
-				{
-					require_once(APPPATH.'controllers/'.$RTR->directory.$error_class.'.php');
-					$e404 = ! class_exists($error_class, FALSE);
-				}
-				// Were we in a directory? If so, check for a global override
-				elseif ( ! empty($RTR->directory) && file_exists(APPPATH.'controllers/'.$error_class.'.php'))
-				{
-					require_once(APPPATH.'controllers/'.$error_class.'.php');
-					if (($e404 = ! class_exists($error_class, FALSE)) === FALSE)
-					{
-						$RTR->directory = '';
-					}
-				}
-			}
-			else
-			{
-				$e404 = FALSE;
-			}
-		}
+    if ( ! class_exists($error_class, FALSE))
+    {
+      if (file_exists(APPPATH.'controllers/'.$RTR->directory.$error_class.'.php'))
+      {
+        require_once(APPPATH.'controllers/'.$RTR->directory.$error_class.'.php');
+        $e404 = ! class_exists($error_class, FALSE);
+      }
+      // Were we in a directory? If so, check for a global override
+      elseif ( ! empty($RTR->directory) && file_exists(APPPATH.'controllers/'.$error_class.'.php'))
+      {
+        require_once(APPPATH.'controllers/'.$error_class.'.php');
+        if (($e404 = ! class_exists($error_class, FALSE)) === FALSE)
+        {
+          $RTR->directory = '';
+        }
+      }
+    }
+    else
+    {
+      $e404 = FALSE;
+    }
+  }
 
-		// Did we reset the $e404 flag? If so, set the rsegments, starting from index 1
-		if ( ! $e404)
-		{
-			$class = $error_class;
-			$method = $error_method;
+  // Did we reset the $e404 flag? If so, set the rsegments, starting from index 1
+  if ( ! $e404)
+  {
+    $class = $error_class;
+    $method = $error_method;
 
-			$URI->rsegments = array(
-				1 => $class,
-				2 => $method
-			);
-		}
-		else
-		{
-			show_404($RTR->directory.$class.'/'.$method);
-		}
-	}
+    $URI->rsegments = array(
+      1 => $class,
+      2 => $method
+    );
+  }
+  else
+  {
+    show_404($RTR->directory.$class.'/'.$method);
+  }
+}
 
-	if ($method !== '_remap')
-	{
-		$params = array_slice($URI->rsegments, 2);
-	}
+if ($method !== '_remap')
+{
+  $params = array_slice($URI->rsegments, 2);
+}
 
 /*
  * ------------------------------------------------------
  *  Is there a "pre_controller" hook?
  * ------------------------------------------------------
  */
-	$EXT->call_hook('pre_controller');
+$EXT->call_hook('pre_controller');
 
 /*
  * ------------------------------------------------------
  *  Instantiate the requested controller
  * ------------------------------------------------------
  */
-	// Mark a start point so we can benchmark the controller
-	$BM->mark('controller_execution_time_( '.$class.' / '.$method.' )_start');
+// Mark a start point so we can benchmark the controller
+$BM->mark('controller_execution_time_( '.$class.' / '.$method.' )_start');
 
-	$CI = new CI_Controller;
+$CI = new CI_Controller;
 
 /*
  * ------------------------------------------------------
  *  Is there a "post_controller_constructor" hook?
  * ------------------------------------------------------
  */
-	$EXT->call_hook('post_controller_constructor');
+$EXT->call_hook('post_controller_constructor');
 
 /*
  * ------------------------------------------------------
  *  Call the requested method
  * ------------------------------------------------------
  */
-	// call_user_func_array(array(&$CI, $method), $params);
+// call_user_func_array(array(&$CI, $method), $params);
 
-	// Mark a benchmark end point
-	$BM->mark('controller_execution_time_( '.$class.' / '.$method.' )_end');
+// Mark a benchmark end point
+$BM->mark('controller_execution_time_( '.$class.' / '.$method.' )_end');
 
 /*
  * ------------------------------------------------------
  *  Is there a "post_controller" hook?
  * ------------------------------------------------------
  */
-	$EXT->call_hook('post_controller');
+$EXT->call_hook('post_controller');
 
 /*
  * ------------------------------------------------------
  *  Send the final rendered output to the browser
  * ------------------------------------------------------
  */
-	if ($EXT->call_hook('display_override') === FALSE)
-	{
-		$OUT->_display();
-	}
+if ($EXT->call_hook('display_override') === FALSE)
+{
+  $OUT->_display();
+}
 
 /*
  * ------------------------------------------------------
  *  Is there a "post_system" hook?
  * ------------------------------------------------------
  */
-	$EXT->call_hook('post_system');
+$EXT->call_hook('post_system');

--- a/phpunit.sample.xml
+++ b/phpunit.sample.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<phpunit bootstrap="vendor/yidas/codeigniter-phpunit/bootstrap.php">
+<phpunit bootstrap="vendor/edgcarmu/codeigniter-phpunit/bootstrap.php">
   <testsuites>
     <testsuite name="TestSuite">
       <directory>tests</directory>


### PR DESCRIPTION
This pull request includes updates to adapt the `codeigniter-phpunit` library for compatibility with CodeIgniter 3.1.11 and PHP 7.1+. The changes involve updating metadata, improving compatibility, and addressing specific configurations in the library files.

### Metadata Updates:
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L2-R15): Updated the `name`, `description`, `homepage`, and `support` fields to reflect the new repository (`edgcarmu/codeigniter-phpunit`) and compatibility with CodeIgniter 3.1.11 and PHP 7.1+. Also updated the PHP requirement to `>=7.1` and PHPUnit dependency to `^7.5`.

### Compatibility Improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R14): Updated references to CodeIgniter and PHP versions to specify compatibility with CodeIgniter 3.1.13 and PHP 7.1+. Changed the logo and description to reflect the official adaptation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R42)
* [`core/CodeIgniter.php`](diffhunk://#diff-46c9ee1deff4886b1711b11e147359f4fc67e4351f45022b07fffc848269f12cL69-R76): Changed `CI_VERSION` from `3.1.10` to `3.1.11` and updated comments to reflect modifications based on `yidas/codeigniter-phpunit`. Adjusted the `get_instance()` function to prevent forced 404 errors. [[1]](diffhunk://#diff-46c9ee1deff4886b1711b11e147359f4fc67e4351f45022b07fffc848269f12cL69-R76) [[2]](diffhunk://#diff-46c9ee1deff4886b1711b11e147359f4fc67e4351f45022b07fffc848269f12cL453-L458)

### Configuration Updates:
* [`bootstrap.php`](diffhunk://#diff-d11e2b9e464a2d6711842693ee58d997e7d238e803fbbe33cea332ece518159eR69-R74): Added a new `ENVIRONMENT` case (`dnamic`) and replaced the `testing` case with `staging` for error reporting configurations.
* [`phpunit.sample.xml`](diffhunk://#diff-dcc7334b4202c56687dd050dbb9c07fdd7e75899422a9c98ccf4dd2639df8b10L2-R2): Updated the bootstrap file path to reference the new repository (`vendor/edgcarmu/codeigniter-phpunit/bootstrap.php`).